### PR TITLE
Update Shipment.php

### DIFF
--- a/src/Resources/ProductOption.php
+++ b/src/Resources/ProductOption.php
@@ -83,4 +83,17 @@ class ProductOption implements Dto, ToRequest
     {
         return $this->maxAttempts;
     }
+    
+    
+    /**
+     * @param string $key
+     * @return bool
+     */
+    public function removeFromRequestData(string $key)
+    {
+        if($key === 'max_attempts' && $this->getOption() !== self::OPTION_PERISHABLE){
+            return true;
+        }
+        return false;
+    }
 }

--- a/src/Resources/ProductOption.php
+++ b/src/Resources/ProductOption.php
@@ -91,7 +91,7 @@ class ProductOption implements Dto, ToRequest
      */
     public function removeFromRequestData(string $key)
     {
-        if($key === 'max_attempts' && $this->getOption() !== self::OPTION_PERISHABLE){
+        if ($key === 'max_attempts' && $this->getOption() !== self::OPTION_PERISHABLE) {
             return true;
         }
         return false;

--- a/src/Resources/Shipment.php
+++ b/src/Resources/Shipment.php
@@ -390,7 +390,14 @@ class Shipment implements Dto, ToRequest, HasShipmentProduct
             ];
         } elseif ($key === 'product_options' && is_array($value)) {
             return array_map(static function (ProductOption $productOption) {
-                return $productOption->toRequest();
+                if ( $productOption->toRequest()['option'] === ProductOption::OPTION_PERISHABLE ) {
+                    return $productOption->toRequest();
+                } else {
+                    $requestArray = $productOption->toRequest();
+                    unset( $requestArray['max_attempts'] );
+
+                    return $requestArray;
+                }
             }, $value);
         }
 

--- a/src/Resources/Shipment.php
+++ b/src/Resources/Shipment.php
@@ -390,11 +390,11 @@ class Shipment implements Dto, ToRequest, HasShipmentProduct
             ];
         } elseif ($key === 'product_options' && is_array($value)) {
             return array_map(static function (ProductOption $productOption) {
-                if ( $productOption->toRequest()['option'] === ProductOption::OPTION_PERISHABLE ) {
+                if ($productOption->toRequest()['option'] === ProductOption::OPTION_PERISHABLE) {
                     return $productOption->toRequest();
                 } else {
                     $requestArray = $productOption->toRequest();
-                    unset( $requestArray['max_attempts'] );
+                    unset($requestArray['max_attempts']);
 
                     return $requestArray;
                 }

--- a/src/Resources/Shipment.php
+++ b/src/Resources/Shipment.php
@@ -390,14 +390,7 @@ class Shipment implements Dto, ToRequest, HasShipmentProduct
             ];
         } elseif ($key === 'product_options' && is_array($value)) {
             return array_map(static function (ProductOption $productOption) {
-                if ($productOption->toRequest()['option'] === ProductOption::OPTION_PERISHABLE) {
-                    return $productOption->toRequest();
-                } else {
-                    $requestArray = $productOption->toRequest();
-                    unset($requestArray['max_attempts']);
-
-                    return $requestArray;
-                }
+                return $productOption->toRequest();
             }, $value);
         }
 


### PR DESCRIPTION
Hi,

I noticed that if you add `ProductOption`s, the following incorrect json payload is generated for the request:
```
"product_options":[
      {
         "option":"allow_neighbours",
         "value":true,
         "max_attempts":null 
      },
      {
         "option":"require_signature",
         "value":false,
         "max_attempts":null
      },
      {
         "option":"age_check_18",
         "value":false,
         "max_attempts":null
      },
      {
         "option":"perishable",
         "value":true,
         "max_attempts":1
      }
   ]
```

The first three occurrences of `"max_attempts":null ` are incorrect following the Redjepakketje API: https://redjepakketje.docs.apiary.io/#reference/endpoints/shipments/create-a-new-shipment-with-label-response

Instead of:
```
   "product_options":[
      {
         "option":"allow_neighbours",
         "value":true
      },
      {
         "option":"require_signature",
         "value":false
      },
      {
         "option":"age_check_18",
         "value":false
      },
      {
         "option":"perishable",
         "value":true,
         "max_attempts":1
      }
   ]
```