### PR TITLE
Add Shipments cancel method

### DIFF
--- a/src/Endpoints/Shipments.php
+++ b/src/Endpoints/Shipments.php
@@ -64,6 +64,28 @@ class Shipments extends Base
 
         return ShipmentResponse::fromArray((array) $data);
     }
+    
+    /**
+     * @param Shipment|string $trackingCode
+     * @return ShipmentResponse
+     * @throws RedJePakketjeException
+     */
+    public function cancel($trackingCode): ShipmentResponse
+    {
+        $apiRoute = $this->client::BASE_ENDPOINT . '/shipments/' . $trackingCode . '/cancel';
+
+        $response = $this->client->doRawRequest('POST', $apiRoute);
+
+        if ($response->getStatusCode() >= 400) {
+            throw new RedJePakketjeException(
+                'Error executing api call, StatusCode: ' . $response->getStatusCode(),
+                $response->getStatusCode()
+            );
+        }
+        $data = ((array) $response)['data'] ?? [];
+
+        return ShipmentResponse::fromArray((array) $data);
+    }
 
     /**
      * @param string $trackingCode


### PR DESCRIPTION
This allows the following behavior:

```
/** @var JacobDeKeizer\RedJePakketje\Client $client */

$trackingCode = 'RETT8XSN4';
$client->shipments()->cancel($trackingcode);
```

It does return a `ShipmentResponse` as per docs example body: https://redjepakketje.docs.apiary.io/#reference/endpoints/shipments/cancel-single-shipment
However, I see that all values are set to null;